### PR TITLE
feat: more filter options for incidents

### DIFF
--- a/eze/src/main/kotlin/org/camunda/community/eze/IncidentRecordStream.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/IncidentRecordStream.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package org.camunda.community.eze
+
+import io.camunda.zeebe.protocol.record.Record
+import io.camunda.zeebe.protocol.record.value.ErrorType
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue
+
+class IncidentRecordStream(private val records: Iterable<Record<IncidentRecordValue>>) :
+        Iterable<Record<IncidentRecordValue>> {
+
+    override fun iterator(): Iterator<Record<IncidentRecordValue>> {
+        return records.iterator()
+    }
+
+    fun withErrorType(errorType: ErrorType): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.errorType == errorType })
+    }
+
+    fun withBpmnProcessId(bpmnProcessId: String): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.bpmnProcessId == bpmnProcessId })
+    }
+
+    fun withProcessDefinitionKey(processDefinitionKey: Long): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.processDefinitionKey == processDefinitionKey })
+    }
+
+    fun withProcessInstanceKey(processInstanceKey: Long): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.processInstanceKey == processInstanceKey })
+    }
+
+    fun withElementId(elementId: String): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.elementId == elementId })
+    }
+
+    fun withElementInstanceKey(elementInstanceKey: Long): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.elementInstanceKey == elementInstanceKey })
+    }
+
+    fun withJobKey(jobKey: Long): IncidentRecordStream {
+        return IncidentRecordStream(filter { it.value.jobKey == jobKey })
+    }
+
+}
+

--- a/eze/src/main/kotlin/org/camunda/community/eze/RecordStream.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/RecordStream.kt
@@ -11,7 +11,9 @@ import io.camunda.zeebe.protocol.record.Record
 import io.camunda.zeebe.protocol.record.RecordType
 import io.camunda.zeebe.protocol.record.RecordValue
 import io.camunda.zeebe.protocol.record.intent.Intent
-import io.camunda.zeebe.protocol.record.value.*
+import io.camunda.zeebe.protocol.record.value.BpmnElementType
+import io.camunda.zeebe.protocol.record.value.JobRecordValue
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue
 import io.camunda.zeebe.test.util.record.CompactRecordLogger
 
 object RecordStream {
@@ -64,33 +66,4 @@ object RecordStream {
         return filter { it.value.type == jobType }
     }
 
-    /* incidents */
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithErrorType(errorType: ErrorType): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.errorType == errorType }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithBpmnProcessId(bpmnProcessId: String): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.bpmnProcessId == bpmnProcessId }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithProcessDefinitionKey(processDefinitionKey: Long): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.processDefinitionKey == processDefinitionKey }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithProcessInstanceKey(processInstanceKey: Long): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.processInstanceKey == processInstanceKey }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithElementId(elementId: String): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.elementId == elementId }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithElementInstanceKey(elementInstanceKey: Long): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.elementInstanceKey == elementInstanceKey }
-    }
-
-    fun Iterable<Record<IncidentRecordValue>>.incidentWithJobKey(jobKey: Long): Iterable<Record<IncidentRecordValue>> {
-        return filter { it.value.jobKey == jobKey }
-    }
 }

--- a/eze/src/main/kotlin/org/camunda/community/eze/RecordStreamSource.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/RecordStreamSource.kt
@@ -19,7 +19,7 @@ interface RecordStreamSource {
 
     fun <T : RecordValue> Iterable<Record<*>>.ofValueType(valueType: ValueType): Iterable<Record<T>> {
         return filter { it.valueType == valueType }
-            .filterIsInstance<Record<T>>()
+                .filterIsInstance<Record<T>>()
     }
 
     fun processInstanceRecords(): Iterable<Record<ProcessInstanceRecordValue>> {
@@ -50,8 +50,8 @@ interface RecordStreamSource {
         return records().ofValueType(ValueType.VARIABLE_DOCUMENT)
     }
 
-    fun incidentRecords(): Iterable<Record<IncidentRecordValue>> {
-        return records().ofValueType(ValueType.INCIDENT)
+    fun incidentRecords(): IncidentRecordStream {
+        return IncidentRecordStream(records().ofValueType(ValueType.INCIDENT))
     }
 
     fun timerRecords(): Iterable<Record<TimerRecordValue>> {


### PR DESCRIPTION
refers to issue #26 

I figured out, that ```.withProcessInstanceKey()``` does clash when using the same method name with more than one generic type (e.g. ProcessInstanceRecordValue and IncidenRecordValue end up in the same method signature).
Seems to be a limit of Kotlin. Also, thinking of Java users, this would lead to problems in using the fluent interface.

So, I do propose to prefix by type. Examples:
- **incident**WithProcessInstanceKey()
- **incident**WithProcessDefinitionKey()
- **incident**WithJobKey()

That should make the use from/within Java more simple and readable.

Any feedback welcome