### PR TITLE
fix: Remove key from delete cache upon write

### DIFF
--- a/eze/src/main/kotlin/org/camunda/community/eze/db/EzeDbTransaction.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/db/EzeDbTransaction.kt
@@ -53,7 +53,9 @@ class EzeDbTransaction(val database : TreeMap<Bytes, Bytes>) : ZeebeDbTransactio
     }
 
     fun put(keyBufferArray: ByteArray, keyLength: Int, valueBufferArray: ByteArray, valueLength: Int) {
-        transactionCache[keyBufferArray.toBytes(keyLength)] = valueBufferArray.toBytes(valueLength)
+        val keyBytes = keyBufferArray.toBytes(keyLength)
+        deletedKeys.remove(keyBytes)
+        transactionCache[keyBytes] = valueBufferArray.toBytes(valueLength)
     }
 
     fun get(keyBufferArray: ByteArray, keyLength: Int): ByteArray? {

--- a/eze/src/test/kotlin/org/camunda/community/eze/db/DbTransactionTest.java
+++ b/eze/src/test/kotlin/org/camunda/community/eze/db/DbTransactionTest.java
@@ -479,6 +479,27 @@ public final class DbTransactionTest {
     assertThat(threeColumnFamily.exists(threeKey)).isFalse();
   }
 
+  @Test
+  public void shouldWriteKeyAfterDeletion() {
+    // given
+    oneKey.wrapLong(1);
+    oneValue.wrapLong(-1);
+    oneColumnFamily.put(oneKey, oneValue);
+
+    // when
+    assertThat(oneColumnFamily.get(oneKey).getValue()).isEqualTo(-1);
+    transactionContext.runInTransaction(
+        () -> {
+          oneColumnFamily.delete(oneKey);
+          oneValue.wrapLong(-2);
+          oneColumnFamily.put(oneKey, oneValue);
+        });
+
+    // then
+    assertThat(oneColumnFamily.exists(oneKey)).isTrue();
+    assertThat(oneColumnFamily.get(oneKey).getValue()).isEqualTo(-2);
+  }
+
   private enum ColumnFamilies {
     DEFAULT, // rocksDB needs a default column family
     ONE,


### PR DESCRIPTION
closes #65 

When putting a key and value in a transaction the key should be removed from the `deletedKeys` cache. Otherwise on commit the value of the key will first be updated, and after this immediately deleted again.

See issue #65 for a more in depth description.

Thanks for letting us copy your code 🙇 