### PR TITLE
Fix writer concurrency

### DIFF
--- a/eze/src/main/kotlin/org/camunda/community/eze/EngineFactory.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/EngineFactory.kt
@@ -65,7 +65,7 @@ object EngineFactory {
         val streamWriter = logStream.newLogStreamRecordWriter().join()
         streamWritersByPartition[partitionId] = streamWriter
 
-        val gateway = GrpcToLogStreamGateway(streamWriter)
+        val gateway = GrpcToLogStreamGateway(logStream.newLogStreamRecordWriter().join())
         val grpcServer = ServerBuilder.forPort(ZeebeEngineImpl.PORT).addService(gateway).build()
 
         val zeebeDb = createDatabase()


### PR DESCRIPTION
The gateway and subscription command sender shared the writers, which caused some concurrency issues

Add regression test similar from https://github.com/camunda-cloud/zeebe-process-test/issues/158