### PR TITLE
feat: include the Zeebe version in the topology

### DIFF
--- a/eze/src/main/kotlin/org/camunda/community/eze/grpc/GrpcToLogStreamGateway.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/grpc/GrpcToLogStreamGateway.kt
@@ -47,6 +47,8 @@ class GrpcToLogStreamGateway(
 
     private val requestIdGenerator = AtomicLong()
 
+    private val versionInfo = getVersionInfo()
+
     private fun writeCommandWithKey(
         key: Long,
         metadata: RecordMetadata,
@@ -426,7 +428,7 @@ class GrpcToLogStreamGateway(
             .addPartitions(partition)
             .setHost("0.0.0.0")
             .setPort(26500)
-            .setVersion(javaClass.`package`.implementationVersion ?: "X.Y.Z")
+            .setVersion(versionInfo)
             .build()
 
         val topologyResponse = GatewayOuterClass.TopologyResponse
@@ -435,7 +437,7 @@ class GrpcToLogStreamGateway(
             .setClusterSize(1)
             .setPartitionsCount(1)
             .setReplicationFactor(1)
-            .setGatewayVersion(javaClass.`package`.implementationVersion ?: "A.B.C")
+            .setGatewayVersion(versionInfo)
             .build()
 
         responseObserver.onNext(topologyResponse)
@@ -492,5 +494,12 @@ class GrpcToLogStreamGateway(
         } catch (ie: InterruptedException) {
             // TODO handle
         }
+    }
+
+    private fun getVersionInfo(): String {
+        val ezeVersion = javaClass.`package`.implementationVersion ?: "dev"
+        val zeebeVersion = RecordMetadata::class.java.`package`.implementationVersion ?: "dev"
+
+        return "$ezeVersion ($zeebeVersion)"
     }
 }

--- a/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
+++ b/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
@@ -76,7 +76,7 @@ class EngineClientTest {
         assertThat(topology.partitionsCount).isEqualTo(1)
         assertThat(topology.gatewayVersion)
             .describedAs("Expect a version with the pattern 'dev (8.1.8)'")
-            .containsPattern("""dev \(8\.\d+\.\d+\)""")
+            .containsPattern("""dev \(8\.\d+\.\d+(-.*)?\)""")
 
         assertThat(topology.brokers).hasSize(1)
         val broker = topology.brokers[0]
@@ -84,7 +84,7 @@ class EngineClientTest {
         assertThat(broker.port).isEqualTo(26500)
         assertThat(broker.version)
             .describedAs("Expect a version with the pattern 'dev (8.1.8)'")
-            .containsPattern("""dev \(8\.\d+\.\d+\)""")
+            .containsPattern("""dev \(8\.\d+\.\d+(-.*)?\)""")
 
         assertThat(broker.partitions).hasSize(1)
         val partition = broker.partitions[0]

--- a/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
+++ b/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
@@ -74,13 +74,17 @@ class EngineClientTest {
         assertThat(topology.clusterSize).isEqualTo(1)
         assertThat(topology.replicationFactor).isEqualTo(1)
         assertThat(topology.partitionsCount).isEqualTo(1)
-        assertThat(topology.gatewayVersion).isEqualTo("A.B.C")
+        assertThat(topology.gatewayVersion)
+            .describedAs("Expect a version with the pattern 'dev (8.1.8)'")
+            .containsPattern("""dev \(8\.\d+\.\d+\)""")
 
         assertThat(topology.brokers).hasSize(1)
         val broker = topology.brokers[0]
         assertThat(broker.host).isEqualTo("0.0.0.0")
         assertThat(broker.port).isEqualTo(26500)
-        assertThat(broker.version).isEqualTo("X.Y.Z")
+        assertThat(broker.version)
+            .describedAs("Expect a version with the pattern 'dev (8.1.8)'")
+            .containsPattern("""dev \(8\.\d+\.\d+\)""")
 
         assertThat(broker.partitions).hasSize(1)
         val partition = broker.partitions[0]


### PR DESCRIPTION
## Description

The gRPC topology response contains the version of the broker and gateway. Adjust the versions to contains not only the version of EZE but also the version of Zeebe. For example, the broker version is `1.2.0 (8.2.0)`.