### PR TITLE
Update Zeebe to `8.2.0-alpha5`

### DIFF
--- a/eze/src/main/kotlin/org/camunda/community/eze/RecordStreamSource.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/RecordStreamSource.kt
@@ -11,6 +11,8 @@ import io.camunda.zeebe.protocol.record.Record
 import io.camunda.zeebe.protocol.record.RecordValue
 import io.camunda.zeebe.protocol.record.ValueType
 import io.camunda.zeebe.protocol.record.value.*
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue
 import io.camunda.zeebe.protocol.record.value.deployment.Process
 import org.camunda.community.eze.records.*
 
@@ -73,6 +75,14 @@ interface RecordStreamSource {
 
     fun processMessageSubscriptionRecords(): Iterable<Record<ProcessMessageSubscriptionRecordValue>> {
         return records().ofValueType(ValueType.PROCESS_MESSAGE_SUBSCRIPTION)
+    }
+
+    fun decisionRequirementsRecords(): Iterable<Record<DecisionRequirementsRecordValue>> {
+        return records().ofValueType(ValueType.DECISION_REQUIREMENTS)
+    }
+
+    fun decisionRecords(): Iterable<Record<DecisionRecordValue>> {
+        return records().ofValueType(ValueType.DECISION)
     }
 
 }

--- a/eze/src/main/kotlin/org/camunda/community/eze/db/EzeDbColumnFamily.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/db/EzeDbColumnFamily.kt
@@ -283,6 +283,33 @@ class EzeDbColumnFamily<ColumnFamilyNames : Enum<ColumnFamilyNames>,
         valueInstance: ValueType,
         visitor: KeyValuePairVisitor<KeyType, ValueType>
     ) {
+        whileWithPrefix(
+            context = context,
+            prefix = prefix,
+            keyInstance = keyInstance,
+            valueInstance = valueInstance,
+            visitor = visitor,
+            predicate = { prefixKey, prefixLength, key ->
+                startsWith(
+                    prefixKey,
+                    0,
+                    prefixLength,
+                    key,
+                    0,
+                    key.size
+                )
+            }
+        )
+    }
+
+    private fun <KeyType : DbKey?, ValueType : DbValue?> whileWithPrefix(
+        context: TransactionContext,
+        prefix: DbKey?,
+        keyInstance: KeyType,
+        valueInstance: ValueType,
+        visitor: KeyValuePairVisitor<KeyType, ValueType>,
+        predicate: (ByteArray, Int, ByteArray) -> Boolean = { _, _, _ -> true }
+    ) {
         columnFamilyContext.withPrefixKey(
             prefix!!
         ) { prefixKey: ByteArray?, prefixLength: Int ->
@@ -293,16 +320,16 @@ class EzeDbColumnFamily<ColumnFamilyNames : Enum<ColumnFamilyNames>,
                 transaction.newIterator().seek(prefixKey!!, prefixLength).iterate().forEach {
 
                     val keyBytes = it.key.byteArray
-                    if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.size)) {
+
+                    val shouldVisit = predicate.invoke(prefixKey, prefixLength, keyBytes)
+                    if (!shouldVisit) {
                         return@forEach
                     }
-                    val shouldVisitNext = visit(keyInstance, valueInstance, visitor, it)
 
+                    val shouldVisitNext = visit(keyInstance, valueInstance, visitor, it)
                     if (!shouldVisitNext) {
                         return@ensureInOpenTransaction
                     }
-
-
                 }
             }
         }
@@ -325,22 +352,12 @@ class EzeDbColumnFamily<ColumnFamilyNames : Enum<ColumnFamilyNames>,
     }
 
     override fun whileTrue(startAtKey: KeyType, visitor: KeyValuePairVisitor<KeyType, ValueType>) {
-
-        columnFamilyContext.withPrefixKey(
-            startAtKey
-        ) { prefixKey: ByteArray?, prefixLength: Int ->
-            ensureInOpenTransaction(
-                context
-            ) { transaction ->
-
-                transaction.newIterator().seek(prefixKey!!, prefixLength).iterate().forEach {
-
-                    val shouldVisitNext = visit(keyInstance, valueInstance, visitor, it)
-                    if (!shouldVisitNext) {
-                        return@ensureInOpenTransaction
-                    }
-                }
-            }
-        }
+        whileWithPrefix(
+            context = context,
+            prefix = startAtKey,
+            keyInstance = keyInstance,
+            valueInstance = valueInstance,
+            visitor = visitor
+        )
     }
 }

--- a/eze/src/main/kotlin/org/camunda/community/eze/engine/EzeStreamProcessorFactory.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/engine/EzeStreamProcessorFactory.kt
@@ -43,6 +43,8 @@ object EzeStreamProcessorFactory {
             .actorSchedulingService(scheduler)
             .streamProcessorMode(StreamProcessorMode.PROCESSING)
             .recordProcessors(listOf(createZeebeEngine(partitionCount)))
+            // disable batch processing until https://github.com/camunda/zeebe/issues/11848 is fixed
+            .maxCommandsInBatch(1)
             .build()
 
         return EzeStreamProcessor(

--- a/eze/src/main/kotlin/org/camunda/community/eze/grpc/GrpcResponseWriter.kt
+++ b/eze/src/main/kotlin/org/camunda/community/eze/grpc/GrpcResponseWriter.kt
@@ -119,6 +119,7 @@ class GrpcResponseWriter(
 
             ValueType.PROCESS_INSTANCE_MODIFICATION -> createProcessInstanceModificationResponse()
             ValueType.DECISION_EVALUATION -> createDecisionEvaluationResponse()
+            ValueType.RESOURCE_DELETION -> createDeleteResourceResponse()
 
             else -> TODO("not supported command '$valueType'")
         }
@@ -370,6 +371,11 @@ class GrpcResponseWriter(
             )
 
         return builder.build()
+    }
+
+    private fun createDeleteResourceResponse(): GatewayOuterClass.DeleteResourceResponse {
+        return GatewayOuterClass.DeleteResourceResponse.newBuilder()
+            .build()
     }
 
     private fun createRejectionResponse(): Status {

--- a/eze/src/main/resources/rating.dmn
+++ b/eze/src/main/resources/rating.dmn
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Ratings" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.8.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="decision_a" name="Decision A">
+    <informationRequirement id="InformationRequirement_1sdnwtv">
+      <requiredDecision href="#decision_b" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1hibhur">
+      <input id="Input_1" label="B">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>decision_b</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="A" name="decision_a" typeRef="string" />
+      <rule id="DecisionRule_1sz0j2x">
+        <inputEntry id="UnaryTests_1r1z1nc">
+          <text>"high"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gbpbaq">
+          <text>"A++"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0gt2ru5">
+        <inputEntry id="UnaryTests_15968nq">
+          <text>"mid"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_007rqht">
+          <text>"A+"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ecrw8b">
+        <inputEntry id="UnaryTests_07gkonx">
+          <text>"low"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pq462u">
+          <text>"A"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision_b" name="Decision B">
+    <decisionTable id="DecisionTable_0ihx504" hitPolicy="FIRST">
+      <input id="InputClause_11xz5ga" label="x">
+        <inputExpression id="LiteralExpression_01im9ul" typeRef="number">
+          <text>x</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0przvpv" label="B" name="decision_b" typeRef="string" />
+      <rule id="DecisionRule_0k1nys1">
+        <inputEntry id="UnaryTests_10glusy">
+          <text>&gt; 10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1cogxsy">
+          <text>"high"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_018nu5a">
+        <inputEntry id="UnaryTests_1ayzs2v">
+          <text>&gt; 5</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_10m4edf">
+          <text>"mid"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1do7v4g">
+        <inputEntry id="UnaryTests_0t9q7uj">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_10g3mkg">
+          <text>"low"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision_a">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_12vg7f9" dmnElementRef="InformationRequirement_1sdnwtv">
+        <di:waypoint x="250" y="240" />
+        <di:waypoint x="250" y="200" />
+        <di:waypoint x="250" y="180" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape id="DMNShape_0xp7kud" dmnElementRef="decision_b">
+        <dc:Bounds height="80" width="180" x="160" y="240" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
+++ b/eze/src/test/kotlin/org/camunda/community/eze/EngineClientTest.kt
@@ -1059,4 +1059,29 @@ class EngineClientTest {
             }
     }
 
+    @Test
+    fun `should evaluate decision`() {
+        // given
+        zeebeClient = ZeebeClient.newClientBuilder().usePlaintext().build()
+        zeebeClient
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("rating.dmn")
+            .send()
+            .join()
+
+        // when
+        val decisionEvaluation =
+            zeebeClient.newEvaluateDecisionCommand()
+                .decisionId("decision_a")
+                .variables(mapOf("x" to 7))
+                .send()
+                .join()
+
+        // then
+        assertThat(decisionEvaluation.decisionId).isEqualTo("decision_a")
+        assertThat(decisionEvaluation.decisionName).isEqualTo("Decision A")
+        assertThat(decisionEvaluation.decisionVersion).isEqualTo(1)
+        assertThat(decisionEvaluation.decisionOutput).isEqualTo("\"A+\"")
+        assertThat(decisionEvaluation.evaluatedDecisions).hasSize(2)
+    }
 }

--- a/eze/src/test/kotlin/org/camunda/community/eze/db/ColumnFamilyTest.java
+++ b/eze/src/test/kotlin/org/camunda/community/eze/db/ColumnFamilyTest.java
@@ -445,6 +445,34 @@ public final class ColumnFamilyTest {
     assertThat(columnFamily.isEmpty()).isTrue();
   }
 
+  @Test
+  public void shouldUseWhileTrueWithStartKey() {
+    // given
+    putKeyValuePair(1, 10);
+    putKeyValuePair(2, 20); // from here ---
+    putKeyValuePair(3, 30);
+    putKeyValuePair(4, 40); // to here   ---
+    putKeyValuePair(5, 50);
+
+    // when
+    key.wrapLong(2);
+
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    columnFamily.whileTrue(
+        key,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+
+          return key.getValue() != 4;
+        });
+
+    // then
+    assertThat(keys).containsExactly(2L, 3L, 4L);
+    assertThat(values).containsExactly(20L, 30L, 40L);
+  }
+
   private void putKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <maven.version>3.0</maven.version>
 
     <kotlin.version>1.8.10</kotlin.version>
-    <zeebe.version>8.2.0-alpha4</zeebe.version>
+    <zeebe.version>8.2.0-alpha5</zeebe.version>
 
     <version.junit>5.9.2</version.junit>
 


### PR DESCRIPTION
## Description

- Update Zeebe from `8.2.0-alpha4` to `8.2.0-alpha5`
- Implement new database API
- Support new decision evaluation API
- Support new resource delete API
- Disable batch processing (because of failing tests)